### PR TITLE
Fix check for text

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -438,7 +438,7 @@ export class AutoComplete {
   private defaultFormatResult(item: any): {} {
     if (typeof item === 'string') {
       return { text: item };
-    } else if (item.text) {
+    } else if ('text' in item) {
       return item;
     } else {
       // return a toString of the item as last resort


### PR DESCRIPTION
The test `if (item.text)` fails for empty string, thus leading creepy
`[Object object]` to be rendered when trying to set value with empty
text