### PR TITLE
Avoid sending extra field when select is converted to autocomplete

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -157,7 +157,6 @@ export class AutoComplete {
     const searchField: JQuery = $('<input>');
     // copy all attributes
     searchField.attr('type', 'search');
-    searchField.attr('name', this._$el.attr('name') + '_text');
     searchField.attr('id', this._$el.attr('id'));
     searchField.attr('disabled', this._$el.attr('disabled'));
     searchField.attr('placeholder', this._$el.attr('placeholder'));


### PR DESCRIPTION
It should not matter to form handler if the value was selected via
plain HTML select or upgraded one with autocomplete.

Sending extra form input violates Principle of Least Astonishment as the
server may refuse to process the request with extra field.