### PR TITLE
Explicitly copy all attributes when upgrading select

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -155,12 +155,17 @@ export class AutoComplete {
 
     // create search input element
     const searchField: JQuery = $('<input>');
+
     // copy all attributes
     searchField.attr('type', 'search');
     searchField.attr('name', this._$el.attr('name') + '_text');
-    searchField.attr('id', this._$el.attr('id'));
-    searchField.attr('disabled', this._$el.attr('disabled'));
-    searchField.attr('placeholder', this._$el.attr('placeholder'));
+    Array.prototype.forEach.call(this._el.attributes, (attr: Attr) => {
+      // Name is already set
+      if (attr.name !== 'name') {
+        searchField.attr(attr.name, attr.value);
+      }
+    });
+
     searchField.attr('autocomplete', 'off');
     searchField.addClass(this._$el.attr('class'));
     if (this._defaultText) {


### PR DESCRIPTION
This should save data-* attributes and even non-standard attributes
supplied with initial markup

This should fix xcash/bootstrap-autocomplete#33