### PR TITLE
Fire `change` event when selection changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -433,6 +433,7 @@ export class AutoComplete {
     this._selectedItem = item;
     // and hide
     this._dd.hide();
+    this._$el.trigger('change');
   }
 
   private defaultFormatResult(item: any): {} {


### PR DESCRIPTION
Modifying input values does not trigger 'change' event byitself.
Triggering it manually to allow external code to observe the changes and
react to them.