### PR TITLE
Preserve selected item when 'show' is invoked

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -456,7 +456,8 @@ export class AutoComplete {
       this.itemSelectedDefaultHandler(null);
     } else if (APICmd === 'show') {
       // shortcut
-      this._$el.trigger('keyup');
+      // Don't trigger keyup because this will reset selected item
+      this.handlerTyped(this._$el.val() as string);
     } else if (APICmd === 'updateResolver') {
       // update resolver
       this.resolver = new AjaxResolver(params);


### PR DESCRIPTION
Invoking 'show' on already populated autocomplete should preserve the selected item.

Previous implementation fired `keyUp` handler which (correctly) assumes that the input text was changed and therefore selected item should be invalidated. But for the 'show' item no change is done, and selection should be preserved so that the field does not get reset on blur if nothing was selected from dropdown 